### PR TITLE
Replace iptables with nftables

### DIFF
--- a/files-main/proxy-firewall-restrict
+++ b/files-main/proxy-firewall-restrict
@@ -33,7 +33,7 @@ nft chain ip qubes input '{ policy drop; }'
 nft chain ip6 qubes input '{ policy drop; }'
 
 # Create output chain since it's not created by Qubes by default
-nft add chain ip qubes output '{ type filter hook output priority 0; policy acceot; }'
+nft add chain ip qubes output '{ type filter hook output priority 0; policy accept; }'
 nft add chain ip6 qubes output '{ type filter hook output priority 0; policy accept; }'
 
 # Disable icmp packets

--- a/files-main/proxy-firewall-restrict
+++ b/files-main/proxy-firewall-restrict
@@ -15,24 +15,25 @@ groupadd -rf qvpn && sync
 
 # Stop all leaks between downstream (vif+) and upstream (Internet eth0):
 nft chain ip qubes forward '{ policy drop; }'
-nft insert rule ip qubes forward oifgroup 1 drop
-nft insert rule ip qubes forward iifgroup 1 drop
+nft insert rule ip qubes custom-forward oifgroup 1 drop
+nft insert rule ip qubes custom-forward iifgroup 1 drop
 
 nft chain ip6 qubes forward '{ policy drop; }'
-nft insert rule ip6 qubes forward oifgroup 1 drop
-nft insert rule ip6 qubes forward iifgroup 1 drop
+nft insert rule ip6 qubes custom-forward oifgroup 1 drop
+nft insert rule ip6 qubes custom-forward iifgroup 1 drop
 
 # Block INPUT from tunnel(s):
 nft chain ip qubes input '{ policy drop; }'
 nft chain ip6 qubes input '{ policy drop; }'
 
+# Create output chain since it's not created by Qubes by default
 nft add chain ip qubes output '{ type filter hook output priority 0; policy drop; }'
 nft add chain ip6 qubes output '{ type filter hook output priority 0; policy drop; }'
 
 # Disable icmp packets
 if [ -e /var/run/qubes-service/vpn-handler-no-icmp ]; then
-  nft insert rule ip qubes input meta l4proto icmp drop
-  nft insert rule ip6 qubes input meta l4proto icmp drop
+  nft insert rule ip qubes custom-input meta l4proto icmp drop
+  nft insert rule ip6 qubes custom-input meta l4proto icmp drop
 
   nft insert rule ip qubes output oifgroup 1 meta l4proto icmp drop
   nft insert rule ip6 qubes output oifgroup 1 meta l4proto icmp drop
@@ -56,3 +57,8 @@ nft insert rule ip qubes output oifgroup 1 skgid qvpn accept
 nft insert rule ip6 qubes output oif "lo" accept
 nft insert rule ip6 qubes output oifgroup 1 skgid qvpn accept
 
+# Accept forward traffic between dowstream (vif+, group 2) and VPN interface (group 9)
+nft insert rule ip qubes custom-forward iifgroup 2 oifgroup 9 accept
+nft insert rule ip qubes custom-forward iifgroup 9 oifgroup 2 accept
+nft insert rule ip6 qubes custom-forward iifgroup 2 oifgroup 9 accept
+nft insert rule ip6 qubes custom-forward iifgroup 9 oifgroup 2 accept

--- a/files-main/proxy-firewall-restrict
+++ b/files-main/proxy-firewall-restrict
@@ -22,13 +22,19 @@ nft chain ip6 qubes forward '{ policy drop; }'
 nft insert rule ip6 qubes custom-forward oifgroup 1 drop
 nft insert rule ip6 qubes custom-forward iifgroup 1 drop
 
+# Accept forward traffic between dowstream (vif+, group 2) and VPN interface (group 9)
+nft insert rule ip qubes custom-forward iifgroup 2 oifgroup 9 accept
+nft insert rule ip qubes custom-forward iifgroup 9 oifgroup 2 accept
+nft insert rule ip6 qubes custom-forward iifgroup 2 oifgroup 9 accept
+nft insert rule ip6 qubes custom-forward iifgroup 9 oifgroup 2 accept
+
 # Block INPUT from tunnel(s):
 nft chain ip qubes input '{ policy drop; }'
 nft chain ip6 qubes input '{ policy drop; }'
 
 # Create output chain since it's not created by Qubes by default
-nft add chain ip qubes output '{ type filter hook output priority 0; policy drop; }'
-nft add chain ip6 qubes output '{ type filter hook output priority 0; policy drop; }'
+nft add chain ip qubes output '{ type filter hook output priority 0; policy acceot; }'
+nft add chain ip6 qubes output '{ type filter hook output priority 0; policy accept; }'
 
 # Disable icmp packets
 if [ -e /var/run/qubes-service/vpn-handler-no-icmp ]; then
@@ -51,14 +57,10 @@ fi
 # Extra restriction prevents accidental communications from within VPN VM to net;
 # The gid-owner rule requires net programs be run with group ID 'qvpn'
 # to allow outbound traffic.
+nft chain ip qubes output '{ policy drop; }'
 nft insert rule ip qubes output oif "lo" accept
 nft insert rule ip qubes output oifgroup 1 skgid qvpn accept
 
+nft chain ip6 qubes output '{ policy drop; }'
 nft insert rule ip6 qubes output oif "lo" accept
 nft insert rule ip6 qubes output oifgroup 1 skgid qvpn accept
-
-# Accept forward traffic between dowstream (vif+, group 2) and VPN interface (group 9)
-nft insert rule ip qubes custom-forward iifgroup 2 oifgroup 9 accept
-nft insert rule ip qubes custom-forward iifgroup 9 oifgroup 2 accept
-nft insert rule ip6 qubes custom-forward iifgroup 2 oifgroup 9 accept
-nft insert rule ip6 qubes custom-forward iifgroup 9 oifgroup 2 accept

--- a/files-main/proxy-firewall-restrict
+++ b/files-main/proxy-firewall-restrict
@@ -14,31 +14,31 @@ groupadd -rf qvpn && sync
 # Set firewall restriction policy
 
 # Stop all leaks between downstream (vif+) and upstream (Internet eth0):
-iptables -P FORWARD DROP
-iptables -I FORWARD -o eth0 -j DROP
-iptables -I FORWARD -i eth0 -j DROP
+nft chain ip qubes forward '{ policy drop; }'
+nft insert rule ip qubes forward oifgroup 1 drop
+nft insert rule ip qubes forward iifgroup 1 drop
 
-ip6tables -P FORWARD DROP
-ip6tables -I FORWARD -o eth0 -j DROP
-ip6tables -I FORWARD -i eth0 -j DROP
+nft chain ip6 qubes forward '{ policy drop; }'
+nft insert rule ip6 qubes forward oifgroup 1 drop
+nft insert rule ip6 qubes forward iifgroup 1 drop
 
 # Block INPUT from tunnel(s):
-iptables  -P INPUT DROP
-ip6tables -P INPUT DROP
+nft chain ip qubes input '{ policy drop; }'
+nft chain ip6 qubes input '{ policy drop; }'
 
-# Allow established v6 traffic (v4 rule already present):
-#iptables -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
+nft add chain ip qubes output '{ type filter hook output priority 0; policy drop; }'
+nft add chain ip6 qubes output '{ type filter hook output priority 0; policy drop; }'
 
 # Disable icmp packets
 if [ -e /var/run/qubes-service/vpn-handler-no-icmp ]; then
-  iptables  -D INPUT -p icmp -j ACCEPT  || true
-  ip6tables -D INPUT -p icmp -j ACCEPT  || true
-  iptables  -I OUTPUT -p icmp -o eth0 -j DROP
-  ip6tables -I OUTPUT -p icmp -o eth0 -j DROP
+  nft insert rule ip qubes input meta l4proto icmp drop
+  nft insert rule ip6 qubes input meta l4proto icmp drop
+
+  nft insert rule ip qubes output oifgroup 1 meta l4proto icmp drop
+  nft insert rule ip6 qubes output oifgroup 1 meta l4proto icmp drop
 else
-  iptables  -I OUTPUT -p icmp -m owner --gid-owner qvpn -j ACCEPT
-  ip6tables -I OUTPUT -p icmp -m owner --gid-owner qvpn -j ACCEPT
+  nft insert rule ip qubes output meta l4proto icmp skgid qvpn accept
+  nft insert rule ip6 qubes output meta l4proto icmp skgid qvpn accept
 fi
 
 ###-------------------------------------------------------------------###
@@ -50,11 +50,9 @@ fi
 # Extra restriction prevents accidental communications from within VPN VM to net;
 # The gid-owner rule requires net programs be run with group ID 'qvpn'
 # to allow outbound traffic.
-iptables -P OUTPUT DROP
-iptables -I OUTPUT -o lo -j ACCEPT
-iptables -I OUTPUT -p all -o eth0 -m owner --gid-owner qvpn -j ACCEPT
+nft insert rule ip qubes output oif "lo" accept
+nft insert rule ip qubes output oifgroup 1 skgid qvpn accept
 
-ip6tables -P OUTPUT DROP
-ip6tables -I OUTPUT -o lo -j ACCEPT
-ip6tables -I OUTPUT -p all -o eth0 -m owner --gid-owner qvpn -j ACCEPT
+nft insert rule ip6 qubes output oif "lo" accept
+nft insert rule ip6 qubes output oifgroup 1 skgid qvpn accept
 

--- a/files-main/qubes-vpn-handler.service
+++ b/files-main/qubes-vpn-handler.service
@@ -22,7 +22,7 @@ Environment="client_cmd=/usr/sbin/openvpn"
 Environment="client_opt1=--cd /rw/config/vpn/ --config /tmp/vpn-client.conf --verb 3"
 Environment="client_opt2=--mlock --ping 10 --ping-restart 42 --connect-retry 5 30"
 Environment="client_opt3=--connect-retry-max 7 --resolv-retry 15 --group qvpn"
-Environment='client_opt4=--script-security 2 --up "/usr/lib/qubes/qubes-vpn-ns up" --down "/usr/lib/qubes/qubes-vpn-ns down"'
+Environment='client_opt4=--script-security 2 --up "/usr/lib/qubes/qubes-vpn-openvpn-script" --down "/usr/lib/qubes/qubes-vpn-openvpn-script"'
 Environment="client_opt5="
 Environment="userpassword_opt=--auth-user-pass /tmp/userpassword.txt"
 

--- a/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
+++ b/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
@@ -26,6 +26,7 @@ ExecStartPre=/bin/sed -i "/~~ function override insertion point/a unset_dns() { 
 
 # Workaround: Allow wg access to net
 ExecStartPre=/sbin/nft chain ip qubes output '{ policy accept; }'
+ExecStartPre=/sbin/nft chain ip6 qubes output '{ policy accept; }'
 ExecStartPost=/sbin/ip link set dev "vpn-client" group 9
 
 ExecStop=/tmp/wg-quick down /tmp/vpn-client.conf

--- a/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
+++ b/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
@@ -21,7 +21,7 @@ Environment="userpassword_opt="
 
 # Override wg-quick DNS functions:
 ExecStartPre=/bin/cp -a /usr/bin/wg-quick /tmp
-ExecStartPre=/bin/sed -i "/~~ function override insertion point/a set_dns() { export vpn_dns=\$DNS; /usr/lib/qubes/qubes-vpn-ns up; HAVE_SET_DNS=1; }" /tmp/wg-quick
+ExecStartPre=/bin/sed -i "/~~ function override insertion point/a set_dns() { export vpn_dns=\$(echo \"\$\{DNS[*]\}\" | sed -e \"s|[[:space:]]\+||g\" -e \"s|,| |g\"); /usr/lib/qubes/qubes-vpn-ns up; HAVE_SET_DNS=1; }" /tmp/wg-quick
 ExecStartPre=/bin/sed -i "/~~ function override insertion point/a unset_dns() { /usr/lib/qubes/qubes-vpn-ns down; }" /tmp/wg-quick
 
 # Workaround: Allow wg access to net

--- a/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
+++ b/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
@@ -21,7 +21,7 @@ Environment="userpassword_opt="
 
 # Override wg-quick DNS functions:
 ExecStartPre=/bin/cp -a /usr/bin/wg-quick /tmp
-ExecStartPre=/bin/sed -i "/~~ function override insertion point/a set_dns() { export vpn_dns=\$(echo \"\$\{DNS[*]\}\" | sed -e \"s|[[:space:]]\+||g\" -e \"s|,| |g\"); /usr/lib/qubes/qubes-vpn-ns up; HAVE_SET_DNS=1; }" /tmp/wg-quick
+ExecStartPre=/bin/sed -i "/~~ function override insertion point/a set_dns() { export vpn_dns=\$\{DNS[*]\}; /usr/lib/qubes/qubes-vpn-ns up; HAVE_SET_DNS=1; }" /tmp/wg-quick
 ExecStartPre=/bin/sed -i "/~~ function override insertion point/a unset_dns() { /usr/lib/qubes/qubes-vpn-ns down; }" /tmp/wg-quick
 
 # Workaround: Allow wg access to net

--- a/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
+++ b/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
@@ -26,9 +26,6 @@ ExecStartPre=/bin/sed -i "/~~ function override insertion point/a unset_dns() { 
 
 # Workaround: Allow wg access to net
 ExecStartPre=/sbin/nft chain ip qubes output '{ policy accept; }'
-ExecStartPost=/sbin/nft insert rule ip qubes forward iifgroup 2 oif "vpn-client" accept
-ExecStartPost=/sbin/nft insert rule ip qubes forward iif "vpn-client" oifgroup 2 accept
-ExecStartPost=/sbin/nft insert rule ip6 qubes forward iifgroup 2 oif "vpn-client" accept
-ExecStartPost=/sbin/nft insert rule ip6 qubes forward iif "vpn-client" oifgroup 2 accept
+ExecStartPost=/sbin/ip link set dev "vpn-client" group 9
 
 ExecStop=/tmp/wg-quick down /tmp/vpn-client.conf

--- a/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
+++ b/files-main/qubes-vpn-handler.service.d/10_wg.conf.example
@@ -25,6 +25,10 @@ ExecStartPre=/bin/sed -i "/~~ function override insertion point/a set_dns() { ex
 ExecStartPre=/bin/sed -i "/~~ function override insertion point/a unset_dns() { /usr/lib/qubes/qubes-vpn-ns down; }" /tmp/wg-quick
 
 # Workaround: Allow wg access to net
-ExecStartPre=/sbin/iptables -P OUTPUT ACCEPT
+ExecStartPre=/sbin/nft chain ip qubes output '{ policy accept; }'
+ExecStartPost=/sbin/nft insert rule ip qubes forward iifgroup 2 oif "vpn-client" accept
+ExecStartPost=/sbin/nft insert rule ip qubes forward iif "vpn-client" oifgroup 2 accept
+ExecStartPost=/sbin/nft insert rule ip6 qubes forward iifgroup 2 oif "vpn-client" accept
+ExecStartPost=/sbin/nft insert rule ip6 qubes forward iif "vpn-client" oifgroup 2 accept
 
 ExecStop=/tmp/wg-quick down /tmp/vpn-client.conf

--- a/files-main/qubes-vpn-ns
+++ b/files-main/qubes-vpn-ns
@@ -42,13 +42,13 @@ up)
         # Set DNS address translation in firewall:
         echo "$vpn_dns " >$nspath
         echo "Using DNS servers $vpn_dns"
-        iptables -t nat -F PR-QBS
+        nft flush chain ip qubes dnat-dns
         . /var/run/qubes/qubes-ns
         q_addr=""
         for DNS in $vpn_dns; do
-            iptables -t nat -I PR-QBS $q_addr -i vif+ -p tcp --dport 53 -j DNAT --to $DNS
-            iptables -t nat -I PR-QBS $q_addr -i vif+ -p udp --dport 53 -j DNAT --to $DNS
-            q_addr="-d $NS1"
+            nft add rule ip qubes dnat-dns iifgroup 2 $q_addr tcp dport 53 dnat to $DNS
+            nft add rule ip qubes dnat-dns iifgroup 2 $q_addr udp dport 53 dnat to $DNS
+            q_addr="ip daddr $NS1"
         done
         do_notify "LINK IS UP." "network-idle"
     else
@@ -71,7 +71,7 @@ test-up)
 
 ;;
 down)
-    iptables -t nat -F PR-QBS
+    nft flush chain ip qubes dnat-dns
     do_notify "LINK IS DOWN !" "dialog-error"
 
 ;;

--- a/files-main/qubes-vpn-ns
+++ b/files-main/qubes-vpn-ns
@@ -43,12 +43,55 @@ up)
         echo "$vpn_dns " >$nspath
         echo "Using DNS servers $vpn_dns"
         nft flush chain ip qubes dnat-dns
+        # ip6 qubes dnat-dns chain is missing upstream so fix it here for now
+        nft add chain ip6 qubes dnat-dns '{ type nat hook prerouting priority dstnat; policy accept; }'
+        nft flush chain ip6 qubes dnat-dns
         . /var/run/qubes/qubes-ns
-        q_addr=""
-        for DNS in $vpn_dns; do
-            nft add rule ip qubes dnat-dns iifgroup 2 $q_addr tcp dport 53 dnat to $DNS
-            nft add rule ip qubes dnat-dns iifgroup 2 $q_addr udp dport 53 dnat to $DNS
-            q_addr="ip daddr $NS1"
+        for NS in $NS1 $NS2; do
+            if [[ $NS =~ .*\..* ]] ; then
+                for DNS in $vpn_dns; do
+                    if [[ $DNS =~ .*\..* ]] ; then
+                        nft add rule ip qubes dnat-dns iifgroup 2 ip daddr $NS tcp dport 53 dnat to $DNS
+                        nft add rule ip qubes dnat-dns iifgroup 2 ip daddr $NS udp dport 53 dnat to $DNS
+                        break
+                    fi
+                done
+            else
+                for DNS in $vpn_dns; do
+                    if [[ $DNS =~ .*:.* ]] ; then
+                        nft add rule ip6 qubes dnat-dns iifgroup 2 ip6 daddr $NS tcp dport 53 dnat to $DNS
+                        nft add rule ip6 qubes dnat-dns iifgroup 2 ip6 daddr $NS udp dport 53 dnat to $DNS
+                        break
+                    fi
+                done
+            fi
+        done
+        # Add fallback rules if no DNS is present in $NS1 and $NS2
+        # Also to redirect all DNS queries to VPN DNS to prevent DNS leaks
+        # This may cause troubles if user want to use some specific
+        # DNS server but it'll redirect queries to VPN DNS instead
+        dns_ipv4_found=0
+        dns_ipv6_found=0
+        for NS in $NS1 $NS2; do
+            if [[ $dns_ipv4_found == 0 ]] && [[ $NS =~ .*\..* ]] ; then
+                for DNS in $vpn_dns; do
+                    if [[ $DNS =~ .*\..* ]] ; then
+                        nft add rule ip qubes dnat-dns iifgroup 2 tcp dport 53 dnat to $DNS
+                        nft add rule ip qubes dnat-dns iifgroup 2 udp dport 53 dnat to $DNS
+                        dns_ipv4_found=1
+                        break
+                    fi
+                done
+            elif [[ $dns_ipv6_found == 0 ]] && [[ $NS =~ .*:.* ]] ; then
+                for DNS in $vpn_dns; do
+                    if [[ $DNS =~ .*:.* ]] ; then
+                        nft add rule ip6 qubes dnat-dns iifgroup 2 tcp dport 53 dnat to $DNS
+                        nft add rule ip6 qubes dnat-dns iifgroup 2 udp dport 53 dnat to $DNS
+                        dns_ipv6_found=1
+                        break
+                    fi
+                done
+            fi
         done
         do_notify "LINK IS UP." "network-idle"
     else
@@ -72,6 +115,7 @@ test-up)
 ;;
 down)
     nft flush chain ip qubes dnat-dns
+    nft flush chain ip6 qubes dnat-dns
     do_notify "LINK IS DOWN !" "dialog-error"
 
 ;;

--- a/files-main/qubes-vpn-ns
+++ b/files-main/qubes-vpn-ns
@@ -38,61 +38,61 @@ up|test-up)
 
 ;;&
 up)
+    # Flush redirects to Qubes OS virtual DNS servers
+    # from qubes connected to this qube
+    nft flush chain ip qubes dnat-dns
+    # ip6 qubes dnat-dns chain is missing upstream so fix it here for now
+    nft add chain ip6 qubes dnat-dns '{ type nat hook prerouting priority dstnat; policy accept; }'
+    nft flush chain ip6 qubes dnat-dns
     if [[ -n "$vpn_dns" ]] ; then
         # Set DNS address translation in firewall:
         echo "$vpn_dns " >$nspath
         echo "Using DNS servers $vpn_dns"
-        nft flush chain ip qubes dnat-dns
-        # ip6 qubes dnat-dns chain is missing upstream so fix it here for now
-        nft add chain ip6 qubes dnat-dns '{ type nat hook prerouting priority dstnat; policy accept; }'
-        nft flush chain ip6 qubes dnat-dns
         . /var/run/qubes/qubes-ns
+        
+        vpn_dns_ip4=()
+        vpn_dns_ip6=()
+        for DNS in $vpn_dns; do
+            if [[ $DNS =~ .*\..* ]] ; then
+                vpn_dns_ip4+=($DNS)
+            elif [[ $DNS =~ .*:.* ]] ; then
+                vpn_dns_ip6+=($DNS)
+            fi
+        done
+
+        qubes_dns_ip4=()
+        qubes_dns_ip6=()
         for NS in $NS1 $NS2; do
             if [[ $NS =~ .*\..* ]] ; then
-                for DNS in $vpn_dns; do
-                    if [[ $DNS =~ .*\..* ]] ; then
-                        nft add rule ip qubes dnat-dns iifgroup 2 ip daddr $NS tcp dport 53 dnat to $DNS
-                        nft add rule ip qubes dnat-dns iifgroup 2 ip daddr $NS udp dport 53 dnat to $DNS
-                        break
-                    fi
-                done
-            else
-                for DNS in $vpn_dns; do
-                    if [[ $DNS =~ .*:.* ]] ; then
-                        nft add rule ip6 qubes dnat-dns iifgroup 2 ip6 daddr $NS tcp dport 53 dnat to $DNS
-                        nft add rule ip6 qubes dnat-dns iifgroup 2 ip6 daddr $NS udp dport 53 dnat to $DNS
-                        break
-                    fi
-                done
+                qubes_dns_ip4+=($NS)
+            elif [[ $NS =~ .*:.* ]] ; then
+                qubes_dns_ip6+=($NS)
             fi
         done
-        # Add fallback rules if no DNS is present in $NS1 and $NS2
-        # Also to redirect all DNS queries to VPN DNS to prevent DNS leaks
-        # This may cause troubles if user want to use some specific
-        # DNS server but it'll redirect queries to VPN DNS instead
-        dns_ipv4_found=0
-        dns_ipv6_found=0
-        for NS in $NS1 $NS2; do
-            if [[ $dns_ipv4_found == 0 ]] && [[ $NS =~ .*\..* ]] ; then
-                for DNS in $vpn_dns; do
-                    if [[ $DNS =~ .*\..* ]] ; then
-                        nft add rule ip qubes dnat-dns iifgroup 2 tcp dport 53 dnat to $DNS
-                        nft add rule ip qubes dnat-dns iifgroup 2 udp dport 53 dnat to $DNS
-                        dns_ipv4_found=1
-                        break
-                    fi
-                done
-            elif [[ $dns_ipv6_found == 0 ]] && [[ $NS =~ .*:.* ]] ; then
-                for DNS in $vpn_dns; do
-                    if [[ $DNS =~ .*:.* ]] ; then
-                        nft add rule ip6 qubes dnat-dns iifgroup 2 tcp dport 53 dnat to $DNS
-                        nft add rule ip6 qubes dnat-dns iifgroup 2 udp dport 53 dnat to $DNS
-                        dns_ipv6_found=1
-                        break
-                    fi
-                done
-            fi
-        done
+
+        if [[ ${#vpn_dns_ip4[@]} != 0 ]] && [[ ${#qubes_dns_ip4[@]} != 0 ]]; then
+            for i in $(seq 0 $((${#qubes_dns_ip4[@]} - 1))); do
+                if [[ $i < ${#vpn_dns_ip4[@]} ]] ; then
+                    nft add rule ip qubes dnat-dns iifgroup 2 ip daddr ${qubes_dns_ip4[$i]} tcp dport 53 dnat to ${vpn_dns_ip4[$i]}
+                    nft add rule ip qubes dnat-dns iifgroup 2 ip daddr ${qubes_dns_ip4[$i]} udp dport 53 dnat to ${vpn_dns_ip4[$i]}
+                else
+                    nft add rule ip qubes dnat-dns iifgroup 2 ip daddr ${qubes_dns_ip4[$i]} tcp dport 53 dnat to ${vpn_dns_ip4[0]}
+                    nft add rule ip qubes dnat-dns iifgroup 2 ip daddr ${qubes_dns_ip4[$i]} udp dport 53 dnat to ${vpn_dns_ip4[0]}
+                fi
+            done
+        fi
+        
+        if [[ ${#vpn_dns_ip6[@]} != 0 ]] && [[ ${#qubes_dns_ip6[@]} != 0 ]]; then
+            for i in $(seq 0 $((${#qubes_dns_ip6[@]} - 1))); do
+                if [[ $i < ${#vpn_dns_ip6[@]} ]] ; then
+                    nft add rule ip6 qubes dnat-dns iifgroup 2 ip6 daddr ${qubes_dns_ip6[$i]} tcp dport 53 dnat to ${qubes_dns_ip6[$i]}
+                    nft add rule ip6 qubes dnat-dns iifgroup 2 ip6 daddr ${qubes_dns_ip6[$i]} udp dport 53 dnat to ${qubes_dns_ip6[$i]}
+                else
+                    nft add rule ip6 qubes dnat-dns iifgroup 2 ip6 daddr ${qubes_dns_ip6[$i]} tcp dport 53 dnat to ${qubes_dns_ip6[0]}
+                    nft add rule ip6 qubes dnat-dns iifgroup 2 ip6 daddr ${qubes_dns_ip6[$i]} udp dport 53 dnat to ${qubes_dns_ip6[0]}
+                fi
+            done
+        fi
         do_notify "LINK IS UP." "network-idle"
     else
         do_notify "LINK UP, NO DNS!" "dialog-error"

--- a/files-main/qubes-vpn-openvpn-script
+++ b/files-main/qubes-vpn-openvpn-script
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+/usr/lib/qubes/qubes-vpn-ns $script_type
+
+case $script_type in
+    up)
+        ip link set dev "$dev" group 9
+        ;;
+esac

--- a/files-main/qubes-vpn-openvpn-script
+++ b/files-main/qubes-vpn-openvpn-script
@@ -4,6 +4,6 @@
 
 case $script_type in
     up)
-        ip link set dev "$dev" group 9
+        /usr/sbin/ip link set dev "$dev" group 9
         ;;
 esac

--- a/files-main/qubes-vpn-setup
+++ b/files-main/qubes-vpn-setup
@@ -185,7 +185,7 @@ if __name__ == '__main__':
         firewall_link /rw/config
         ln -s -f /rw/config/qubes-vpn-setup /usr/lib/qubes/qubes-vpn-setup
         ln -s -f /rw/config/qubes-vpn-ns /usr/lib/qubes/qubes-vpn-ns
-        ln -s -f /rw/config/qubes-vpn-ns /usr/lib/qubes/qubes-vpn-openvpn-script
+        ln -s -f /rw/config/qubes-vpn-openvpn-script /usr/lib/qubes/qubes-vpn-openvpn-script
         echo "copy complete."
         do_userpass
         echo "Done!"

--- a/files-main/qubes-vpn-setup
+++ b/files-main/qubes-vpn-setup
@@ -53,7 +53,7 @@ firewall_link() {
 case "$1" in
 --check-firewall)
     for i in 1 2 3; do
-        if (nft -j -s list chain ip qubes forward && nft -j -s list chain ip qubes forward) | python3 -c "
+        if (nft -j -s list chain ip qubes custom-forward && nft -j -s list chain ip qubes custom-forward) | python3 -c "
 import sys, json;
 def main():
   rule_out_ipv4_exists = False
@@ -162,7 +162,8 @@ if __name__ == '__main__':
 
     if [ ! -d vpn ]; then exit 1; fi
     chown -R root:root *
-    chmod +x rc.local qubes-vpn-ns qubes-vpn-setup proxy-firewall-restrict
+    chmod +x rc.local qubes-vpn-ns qubes-vpn-openvpn-script \
+      qubes-vpn-setup proxy-firewall-restrict
 
     if [ -e /var/run/qubes/this-is-templatevm ]; then
         echo "Install into templateVM..."
@@ -170,8 +171,8 @@ if __name__ == '__main__':
         cp -a qubes-vpn-handler.service* /lib/systemd/system
         sync; sleep 2s; systemctl daemon-reload
         systemctl enable qubes-vpn-handler.service
-        cp -a qubes-vpn-ns qubes-vpn-setup proxy-firewall-restrict \
-    -t /usr/lib/qubes
+        cp -a qubes-vpn-ns qubes-vpn-openvpn-script qubes-vpn-setup \
+          proxy-firewall-restrict -t /usr/lib/qubes
         echo "Almost done..."
         echo "Next, shutdown this template then start proxyVM and run:"
         echo "sudo /usr/lib/qubes/qubes-vpn-setup --config"
@@ -179,10 +180,12 @@ if __name__ == '__main__':
     elif [ -e /var/run/qubes/this-is-proxyvm ]; then
         echo -n "Isolated install for proxyVM..."
         cp -a vpn rc.local qubes-vpn-handler.* qubes-vpn-setup \
-          qubes-vpn-ns proxy-firewall-restrict -t /rw/config
+          qubes-vpn-ns qubes-vpn-openvpn-script proxy-firewall-restrict \
+          -t /rw/config
         firewall_link /rw/config
         ln -s -f /rw/config/qubes-vpn-setup /usr/lib/qubes/qubes-vpn-setup
         ln -s -f /rw/config/qubes-vpn-ns /usr/lib/qubes/qubes-vpn-ns
+        ln -s -f /rw/config/qubes-vpn-ns /usr/lib/qubes/qubes-vpn-openvpn-script
         echo "copy complete."
         do_userpass
         echo "Done!"
@@ -202,14 +205,16 @@ if __name__ == '__main__':
         rm -rf /lib/systemd/system/qubes-vpn-handler.service.d
         systemctl daemon-reload
         cd /usr/lib/qubes
-        rm -f qubes-vpn-ns qubes-vpn-setup proxy-firewall-restrict
+        rm -f qubes-vpn-ns qubes-vpn-openvpn-script qubes-vpn-setup \
+          proxy-firewall-restrict
         )
         echo qubes-vpn-handler removed.
     elif is_proxyvm ; then
         ( cd /rw/config
         rm -rf qubes-vpn-handler.service
         rm -rf qubes-vpn-handler.service.d
-        rm -f qubes-vpn-ns qubes-vpn-setup proxy-firewall-restrict
+        rm -f qubes-vpn-ns qubes-vpn-openvpn-script qubes-vpn-setup \
+          proxy-firewall-restrict
         mv -v rc.local rc.local-qvpn-disabled
         )
         echo qubes-vpn-handler removed.

--- a/files-main/qubes-vpn-setup
+++ b/files-main/qubes-vpn-setup
@@ -53,10 +53,53 @@ firewall_link() {
 case "$1" in
 --check-firewall)
     for i in 1 2 3; do
-        if iptables -C FORWARD -o eth0 -j DROP \
-        && iptables -C FORWARD -i eth0 -j DROP  \
-        && ip6tables -C FORWARD -o eth0 -j DROP  \
-        && ip6tables -C FORWARD -i eth0 -j DROP ; then
+        if (nft -j -s list chain ip qubes forward && nft -j -s list chain ip qubes forward) | python3 -c "
+import sys, json;
+def main():
+  rule_out_ipv4_exists = False
+  rule_in_ipv4_exists = False
+  rule_out_ipv6_exists = False
+  rule_in_ipv6_exists = False
+  nft_rules = sys.stdin.readlines()
+  nft_rules_ip = json.loads(nft_rules[0])['nftables']
+  nft_rules_ip6 = json.loads(nft_rules[1])['nftables']
+  for nft_rule in nft_rules_ip:
+    for nft_rule_item in nft_rule.items():
+      rule_expr0 = False
+      rule_expr1 = False
+      if 'expr' in nft_rule_item[1]:
+        for expr_item in nft_rule_item[1]['expr']:
+          if 'match' in expr_item and 'meta' in expr_item['match']['left'] and expr_item['match']['op'] == '==' and expr_item['match']['right'] == 1:
+            rule_expr0 = True
+          if 'drop' in expr_item and expr_item['drop'] == None:
+            rule_expr1 = True
+        if rule_expr0 and rule_expr1:
+          if nft_rule_item[1]['expr'][0]['match']['left']['meta']['key'] == 'oifgroup':
+            rule_out_ipv4_exists = True
+          elif nft_rule_item[1]['expr'][0]['match']['left']['meta']['key'] == 'iifgroup':
+            rule_in_ipv4_exists = True
+  for nft_rule in nft_rules_ip6:
+    for nft_rule_item in nft_rule.items():
+      rule_expr0 = False
+      rule_expr1 = False
+      if 'expr' in nft_rule_item[1]:
+        for expr_item in nft_rule_item[1]['expr']:
+          if 'match' in expr_item and 'meta' in expr_item['match']['left'] and expr_item['match']['op'] == '==' and expr_item['match']['right'] == 1:
+            rule_expr0 = True
+          if 'drop' in expr_item and expr_item['drop'] == None:
+            rule_expr1 = True
+        if rule_expr0 and rule_expr1:
+          if nft_rule_item[1]['expr'][0]['match']['left']['meta']['key'] == 'oifgroup':
+            rule_out_ipv6_exists = True
+          elif nft_rule_item[1]['expr'][0]['match']['left']['meta']['key'] == 'iifgroup':
+            rule_in_ipv6_exists = True
+  if rule_out_ipv4_exists and rule_in_ipv4_exists and rule_out_ipv6_exists and rule_in_ipv6_exists:
+    sys.exit(0)
+  else:
+    sys.exit(1)
+if __name__ == '__main__':
+  main()
+        "; then
             exit 0
         elif [ $i = 3 ]; then
             echo "Error: Firewall rule(s) not enabled!"

--- a/files-main/rc.local
+++ b/files-main/rc.local
@@ -11,6 +11,7 @@ fi
 cp -a /rw/config/qubes-vpn-handler.* /lib/systemd/system
 sync
 ln -s -f /rw/config/qubes-vpn-ns /usr/lib/qubes/qubes-vpn-ns
+ln -s -f /rw/config/qubes-vpn-openvpn-script /usr/lib/qubes/qubes-vpn-openvpn-script
 ln -s -f /rw/config/qubes-vpn-setup /usr/lib/qubes/qubes-vpn-setup
 
 # Start tunnel service


### PR DESCRIPTION
Qubes dropped iptables support and replaced it with nftables:
https://github.com/QubesOS/qubes-core-agent-linux/commit/28b95535c7cbd15543c804e822c0e4c997f5966e
This pull request replaces iptables with nftables.

Removed `allow established input` rules from `proxy-firewall-restrict` since they are already present in nft tables ip/ip6 qubes.

TODO: Need to think of a better way to check in `--check-firewall` in `qubes-vpn-setup` script if the forward drop rules are present (or `proxy-firewall-restrict` script finished successfully).